### PR TITLE
Look for the MAX30208 in two addresses

### DIFF
--- a/app/src/hw_module.c
+++ b/app/src/hw_module.c
@@ -103,7 +103,8 @@ LOG_MODULE_REGISTER(hw_module, LOG_LEVEL_DBG);
 char curr_string[40];
 
 // Peripheral Device Pointers
-static const struct device *max30208_dev = DEVICE_DT_GET_ANY(maxim_max30208);
+static const struct device *max30208a50_dev = DEVICE_DT_GET(DT_NODELABEL(max30208a50));
+static const struct device *max30208a52_dev = DEVICE_DT_GET(DT_NODELABEL(max30208a52));
 
 const struct device *max32664d_dev = DEVICE_DT_GET_ANY(maxim_max32664);
 const struct device *max32664c_dev = DEVICE_DT_GET_ANY(maxim_max32664c);
@@ -580,8 +581,8 @@ double read_temp_f(void)
 {
     struct sensor_value temp_sample;
 
-    sensor_sample_fetch(max30208_dev);
-    sensor_channel_get(max30208_dev, SENSOR_CHAN_AMBIENT_TEMP, &temp_sample);
+    sensor_sample_fetch(max30208a50_dev);
+    sensor_channel_get(max30208a50_dev, SENSOR_CHAN_AMBIENT_TEMP, &temp_sample);
     // last_read_temp_value = temp_sample.val1;
     double temp_c = (double)temp_sample.val1 * 0.005;
     double temp_f = (temp_c * 1.8) + 32.0;
@@ -734,7 +735,7 @@ void hw_module_init(void)
     NRF_TWIM1->FREQUENCY = 0x06200000;
 
     // Debug: Scan I2C2 bus for available devices before initialization
-    // i2c2_bus_scan_debug();
+    //i2c2_bus_scan_debug();
 
     if (!device_is_ready(pmic))
     {
@@ -1097,18 +1098,33 @@ void hw_module_init(void)
 
     // setup_pmic_callbacks();
 
-    device_init(max30208_dev);
+    device_init(max30208a50_dev);
     k_sleep(K_MSEC(100));
 
-    if (!device_is_ready(max30208_dev))
+    if (!device_is_ready(max30208a50_dev))
     {
-        LOG_ERR("MAX30208 device not found!");
-        hw_add_boot_msg("MAX30208", false, true, false, 0);
+        LOG_ERR("MAX30208A50 device not found!");
+        hw_add_boot_msg("MAX30208 @50", false, true, false, 0);        
     }
     else
     {
-        LOG_INF("MAX30208 device found!");
-        hw_add_boot_msg("MAX30208", true, true, false, 0);
+        LOG_INF("MAX30208A50 device found!");
+        hw_add_boot_msg("MAX30208A50 @50", true, true, false, 0);
+    }
+
+    device_init(max30208a52_dev);
+    k_sleep(K_MSEC(100));
+
+    if (!device_is_ready(max30208a52_dev))
+    {
+        LOG_ERR("MAX30208A52 device not found!");
+        hw_add_boot_msg("MAX30208 @52", false, true, false, 0);
+    }
+    else
+    {
+        max30208a50_dev = max30208a52_dev; // Use the device with address 0x52
+        LOG_INF("MAX30208A52 device found!");
+        hw_add_boot_msg("MAX30208 @52", true, true, false, 0);
     }
 
     hw_add_boot_msg("Boot complete !!", true, false, false, 0);

--- a/app/src/ui/screens/scr_boot.c
+++ b/app/src/ui/screens/scr_boot.c
@@ -93,6 +93,7 @@ void draw_scr_boot(void)
     label_boot_messages = lv_label_create(scroll_container);
     lv_label_set_text(label_boot_messages, "");
     lv_obj_set_width(label_boot_messages, LV_PCT(100));
+    lv_obj_set_height(label_boot_messages, LV_SIZE_CONTENT);
     lv_label_set_long_mode(label_boot_messages, LV_LABEL_LONG_WRAP);
     lv_obj_set_style_text_color(label_boot_messages, lv_color_white(), LV_PART_MAIN);
     lv_obj_align(label_boot_messages, LV_ALIGN_TOP_LEFT, 0, 0);
@@ -131,8 +132,15 @@ void scr_boot_add_status(char *dev_label, bool status, bool show_status)
 
     lv_label_set_text(label_boot_messages, full_text);
 
+    // Refresh the label to ensure proper sizing
+    lv_obj_refresh_style(label_boot_messages, LV_PART_ANY, LV_STYLE_PROP_ANY);
+    lv_obj_update_layout(scroll_container);
+    
+    // Force LVGL to process tasks and then scroll
+    lv_task_handler();
+    
     // Auto-scroll to bottom to show latest message
-    lv_obj_scroll_to_y(scroll_container, LV_COORD_MAX, LV_ANIM_ON);
+    lv_obj_scroll_to_y(scroll_container, LV_COORD_MAX, LV_ANIM_OFF);
 }
 
 void scr_boot_add_final(bool status)
@@ -158,6 +166,13 @@ void scr_boot_add_final(bool status)
 
     lv_label_set_text(label_boot_messages, full_text);
 
+    // Refresh the label to ensure proper sizing
+    lv_obj_refresh_style(label_boot_messages, LV_PART_ANY, LV_STYLE_PROP_ANY);
+    lv_obj_update_layout(scroll_container);
+    
+    // Force LVGL to process tasks and then scroll
+    lv_task_handler();
+    
     // Auto-scroll to bottom to show final message
-    lv_obj_scroll_to_y(scroll_container, LV_COORD_MAX, LV_ANIM_ON);
+    lv_obj_scroll_to_y(scroll_container, LV_COORD_MAX, LV_ANIM_OFF);
 }

--- a/boards/protocentral/healthypi_move/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/protocentral/healthypi_move/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -30,8 +30,8 @@
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 0, 24)>,
 					<NRF_PSEL(TWIM_SCL, 0, 25)>;
-			//bias-pull-up;
-			//nordic,drive-mode = <NRF_DRIVE_S0D1>;//<NRF_DRIVE_H0H1>;
+			bias-pull-up;
+			nordic,drive-mode = <NRF_DRIVE_S0D1>;//<NRF_DRIVE_H0H1>;
 
 		};
 	};
@@ -41,8 +41,8 @@
 			psels = <NRF_PSEL(TWIM_SDA, 0, 24)>,
 					<NRF_PSEL(TWIM_SCL, 0, 25)>;
 			low-power-enable;
-			//bias-pull-up;
-			//nordic,drive-mode = <NRF_DRIVE_S0D1>;//<NRF_DRIVE_H0H1>;// <NRF_DRIVE_S0D1>;
+			bias-pull-up;
+			nordic,drive-mode = <NRF_DRIVE_S0D1>;//<NRF_DRIVE_H0H1>;// <NRF_DRIVE_S0D1>;
 
 		};
 	};

--- a/boards/protocentral/healthypi_move/nrf5340_cpuapp_common.dtsi
+++ b/boards/protocentral/healthypi_move/nrf5340_cpuapp_common.dtsi
@@ -269,7 +269,14 @@
 		zephyr,deferred-init;
 	};
 
-	max30208: max30208@52 {
+	max30208a50: max30208a50@50 {
+		compatible = "maxim,max30208";
+		status = "okay";
+		reg = <0x50>;
+		zephyr,deferred-init;
+	};
+
+	max30208a52: max30208a52@52 {
 		compatible = "maxim,max30208";
 		status = "okay";
 		reg = <0x52>;

--- a/drivers/sensor/max30208/max30208.c
+++ b/drivers/sensor/max30208/max30208.c
@@ -38,7 +38,7 @@ static uint8_t max30208_read_reg(const struct device *dev, uint8_t reg, uint8_t 
 {
 	const struct max30208_config *config = dev->config;
 
-	struct i2c_msg m_msgs[2];
+	/*struct i2c_msg m_msgs[2];
 	uint8_t reg_buf[1] = {reg};
 
 	m_msgs[0].buf = reg_buf;
@@ -53,10 +53,17 @@ static uint8_t max30208_read_reg(const struct device *dev, uint8_t reg, uint8_t 
 	if (ret < 0)
 	{
 		LOG_ERR("Failed to read register: %d", ret);
-	}
+	}*/
+
+	uint8_t wr_buf[1] = {reg};
+	int ret = 0;
+
+	ret = i2c_write_dt(&config->i2c, wr_buf, sizeof(wr_buf));
+	k_sleep(K_MSEC(10));
+	ret = i2c_read_dt(&config->i2c, read_buf, read_len);
 
 	// printk("Read register: %x\n", read_buf[0]);
-	return 0;
+	return ret;
 }
 
 static int max30208_write_reg(const struct device *dev, uint8_t reg, uint8_t val)
@@ -70,7 +77,7 @@ static int max30208_write_reg(const struct device *dev, uint8_t reg, uint8_t val
 	return 0;
 }
 
-static int max30208_get_chip_id(const struct device *dev, uint8_t* id)
+static int max30208_get_chip_id(const struct device *dev, uint8_t *id)
 {
 	uint8_t read_buf[1] = {0};
 
@@ -166,7 +173,7 @@ static int max30208_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if(chip_id[0] != MAX30208_CHIP_ID)
+	if (chip_id[0] != MAX30208_CHIP_ID)
 	{
 		LOG_ERR("Invalid chip id: %x", chip_id[0]);
 		return -ENODEV;


### PR DESCRIPTION
This pull request introduces support for two separate MAX30208 temperature sensor devices (`max30208a50` and `max30208a52`) with distinct I2C addresses, updates initialization and error handling logic to accommodate both, and improves the boot screen UI for better message handling. Additionally, it modifies pin configuration settings for I2C peripherals and refactors the MAX30208 driver to improve register read operations.

**Hardware device support and initialization:**

* Added support for two MAX30208 devices (`max30208a50` at address 0x50 and `max30208a52` at address 0x52) in the device tree (`nrf5340_cpuapp_common.dtsi`) and updated peripheral pointers in `hw_module.c` to reference them separately. [[1]](diffhunk://#diff-a0e374a126914c3c0a859c79ffc1ddd7429d10dd3ae5525d37e03779dbe19730L272-R279) [[2]](diffhunk://#diff-7f05f3dcca529f606d8f24fbdb5eb26d8d24c5ad12c9d49e4c44924a06d883cfL106-R107)
* Updated initialization logic in `hw_module_init` to initialize, check readiness, and log status for both devices, including dynamic switching to the device at address 0x52 if available. Boot messages now reflect the specific device addresses.
* Changed temperature reading function to use the new device pointer (`max30208a50_dev`).

**UI improvements for boot screen:**

* Improved boot message label sizing and layout refresh in `scr_boot.c` to ensure proper display and auto-scrolling behavior, including switching scroll animation off for smoother updates. [[1]](diffhunk://#diff-9385177961078c371decc4fc9b6d84f1a3ea24edb1c3da79bdbdd4bb20e15504R96) [[2]](diffhunk://#diff-9385177961078c371decc4fc9b6d84f1a3ea24edb1c3da79bdbdd4bb20e15504R135-R143) [[3]](diffhunk://#diff-9385177961078c371decc4fc9b6d84f1a3ea24edb1c3da79bdbdd4bb20e15504R169-R177)

**I2C pin configuration:**

* Enabled pull-up bias and set drive mode for I2C pins in the pinctrl device tree file, ensuring reliable communication with the sensors. [[1]](diffhunk://#diff-13eba975a4c1191835cdec7ae8d54cfafc032a3eb3bf115b6e1597da7a4d6281L33-R34) [[2]](diffhunk://#diff-13eba975a4c1191835cdec7ae8d54cfafc032a3eb3bf115b6e1597da7a4d6281L44-R45)

**MAX30208 driver refactor:**

* Refactored register read operation in the MAX30208 driver to use separate I2C write and read calls instead of a message array, improving compatibility and reliability. [[1]](diffhunk://#diff-0d9e41398930607ede031936296ddd70ca151eff0043b1348cf68de71d946c5fL41-R41) [[2]](diffhunk://#diff-0d9e41398930607ede031936296ddd70ca151eff0043b1348cf68de71d946c5fL56-R66)