### PR TITLE
Fix PPG sensor display issue

### DIFF
--- a/app/src/hw_module.c
+++ b/app/src/hw_module.c
@@ -603,7 +603,7 @@ void hw_module_init(void)
     NRF_TWIM1->FREQUENCY = 0x06200000;
 
     // Debug: Scan I2C2 bus for available devices before initialization
-    //i2c2_bus_scan_debug();
+    // i2c2_bus_scan_debug();
 
     if (!device_is_ready(pmic))
     {
@@ -973,26 +973,26 @@ void hw_module_init(void)
     {
         LOG_ERR("MAX30208A50 device not found!");
         hw_add_boot_msg("MAX30208 @50", false, true, false, 0);
+
+        device_init(max30208a52_dev);
+        k_sleep(K_MSEC(100));
+
+        if (!device_is_ready(max30208a52_dev))
+        {
+            LOG_ERR("MAX30208A52 device not found!");
+            hw_add_boot_msg("MAX30208 @52", false, true, false, 0);
+        }
+        else
+        {
+            max30208a50_dev = max30208a52_dev; // Use the device with address 0x52
+            LOG_INF("MAX30208A52 device found!");
+            hw_add_boot_msg("MAX30208 @52", true, true, false, 0);
+        }
     }
     else
     {
         LOG_INF("MAX30208A50 device found!");
         hw_add_boot_msg("MAX30208A50 @50", true, true, false, 0);
-    }
-
-    device_init(max30208a52_dev);
-    k_sleep(K_MSEC(100));
-
-    if (!device_is_ready(max30208a52_dev))
-    {
-        LOG_ERR("MAX30208A52 device not found!");
-        hw_add_boot_msg("MAX30208 @52", false, true, false, 0);
-    }
-    else
-    {
-        max30208a50_dev = max30208a52_dev; // Use the device with address 0x52
-        LOG_INF("MAX30208A52 device found!");
-        hw_add_boot_msg("MAX30208 @52", true, true, false, 0);
     }
 
     hw_add_boot_msg("Boot complete !!", true, false, false, 0);


### PR DESCRIPTION
This pull request introduces significant improvements to the wrist PPG state machine and sensor handling logic, along with some code style and documentation updates. The changes enhance motion detection reliability, optimize power usage, and improve the visualization of PPG data.

**State Machine and Motion Detection Enhancements:**

* Added a new `MOTION_DETECT` state to the wrist PPG state machine, allowing the system to poll the FIFO after a wake-on-motion event to confirm actual motion before fully activating algorithms. This improves robustness and power efficiency. [[1]](diffhunk://#diff-e8f153691e68fedfb265c7353943ddf6df9cff9ee4b3741c46e65337dee46836L547-R583) [[2]](diffhunk://#diff-e8f153691e68fedfb265c7353943ddf6df9cff9ee4b3741c46e65337dee46836L568-R643)
* Updated state transitions so that motion detection now leads to the `MOTION_DETECT` state instead of immediately activating algorithms, and added a semaphore (`sem_ppg_wrist_motion_fifo`) for FIFO sample notification. [[1]](diffhunk://#diff-e8f153691e68fedfb265c7353943ddf6df9cff9ee4b3741c46e65337dee46836R80) [[2]](diffhunk://#diff-e8f153691e68fedfb265c7353943ddf6df9cff9ee4b3741c46e65337dee46836L221-R237) [[3]](diffhunk://#diff-e8f153691e68fedfb265c7353943ddf6df9cff9ee4b3741c46e65337dee46836L547-R583)

**Sampling Interval and Algorithm Adjustments:**

* Increased both passive and active wrist PPG sampling intervals to 160ms for reduced power consumption and more consistent timing.

**PPG Data Visualization Improvements:**

* Changed the PPG plot to use green channel data instead of IR, and added simple DC removal using an EMA baseline to center the signal for better visualization and avoid coordinate wrapping issues.

**Sensor Handling and Initialization:**


* Adjusted sensor reporting period and removed unused configuration macros for streamlined sensor operation.
