### PR TITLE
Fix issue with finger-sensor SpO2

### DIFF
--- a/app/src/hw_module.h
+++ b/app/src/hw_module.h
@@ -42,8 +42,8 @@ void hpi_bpt_abort(void);
 
 void hpi_hw_pmic_off(void);
 
-void hpi_hw_ldsw2_off(void);
-void hpi_hw_ldsw2_on(void);
+void hpi_hw_fi_sensor_off(void);
+void hpi_hw_fi_sensor_on(void);
 
 void hpi_pwr_display_sleep(void);
 void hpi_pwr_display_wake(void);


### PR DESCRIPTION
This pull request refactors how the Finger Identification (FI) sensor power rail is managed throughout the hardware and state machine modules. This change enhances code clarity, ensures consistent FI sensor power management, and improves robustness during sensor detection and operation.

**FI Sensor Power Management Refactor**

* Replaced direct usage of the `ldsw_sens_1_8` regulator pointer with a new identifier `dev_ldsw_fi_sens`, and introduced wrapper functions `hpi_hw_fi_sensor_on()` and `hpi_hw_fi_sensor_off()` for controlling the FI sensor power rail. All previous calls to the regulator for FI sensor are now routed through these wrappers for better abstraction. 

**State Machine Integration**

* Modified the PPG Finger state machine (`smf_ppg_finger.c`) to consistently power on the FI sensor before calibration, estimation, and SpO2 operations, and to power it off after completion, failure, or timeout. This includes robust handling for sensor detection retries, where the FI sensor rail is power-cycled up to three times if the sensor ID read fails.